### PR TITLE
check if cb is defined before calling in destroy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,11 +148,14 @@ module.exports = ({ Store }) => {
           )
           .run(sid);
       } catch (err) {
-        cb(err);
+        if (cb) {
+          cb(err);
+        }
         return;
       }
-
-      cb(null, res);
+      if (cb) {
+        cb(null, res);
+      }
     }
 
     length(cb) {


### PR DESCRIPTION
When req.session.destroy() is called without any parameter in express, cb in destroy() throws an error since it is not defined.
