### PR TITLE
Allow setting a session with the expires prop set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,17 +67,23 @@ module.exports = ({ Store }) => {
     }
 
     set(sid, sess, cb = noop) {
-      let age;
       // NOTE: Express's temporal unit of choice is milliseconds:
       // http://expressjs.com/en/resources/middleware/session.html#:~:text=cookie.maxAge
+      const now = new Date().getTime();
+      let expire;
+
+      // MaxAge takes precedence over Expires
       if (sess.cookie && sess.cookie.maxAge) {
-        age = sess.cookie.maxAge;
+        expire = new Date(now + sess.cookie.maxAge).toISOString();
+      } else if (sess.cookie && sess.cookie.expires) {
+        expire =
+          typeof sess.cookie.expires === "object"
+            ? sess.cookie.expires.toISOString()
+            : new Date(sess.cookie.expires).toISOString();
       } else {
-        age = oneDay;
+        expire = new Date(now + oneDay).toISOString();
       }
 
-      const now = new Date().getTime();
-      const expire = new Date(now + age).toISOString();
       const entry = { sid, sess: JSON.stringify(sess), expire };
 
       let res;

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -146,7 +146,7 @@ test("if it saves a session with a missing maxAge too", (t) => {
   );
 });
 
-test("if it saves a session with expires value (as Date object) set instead of maxAge", async (t) => {
+test("if it saves a session with expires value (as Date object) set instead of maxAge", (t) => {
   const db = new sqlite(dbName, dbOptions);
   const s = new SqliteStore({
     client: db,


### PR DESCRIPTION
The current code was setting the `expire` value always one day into the future even if the `cookie.expires` prop was set.

No worries, tests will follow 😅